### PR TITLE
Add new event and modify some workflow

### DIFF
--- a/src/Events/AttemptSucceded.php
+++ b/src/Events/AttemptSucceded.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace FrancescoMalatesta\LaravelCircuitBreaker\Events;
+
+class AttemptSucceded
+{
+    /** @var string */
+    private $identifier;
+
+    /**
+     * AttemptFailed constructor.
+     * @param string $identifier
+     */
+    public function __construct(string $identifier)
+    {
+        $this->identifier = $identifier;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+}

--- a/src/Events/AttemptSucceeded.php
+++ b/src/Events/AttemptSucceeded.php
@@ -8,7 +8,7 @@ class AttemptSucceeded
     private $identifier;
 
     /**
-     * AttemptFailed constructor.
+     * AttemptSucceeded constructor.
      * @param string $identifier
      */
     public function __construct(string $identifier)

--- a/src/Events/AttemptSucceeded.php
+++ b/src/Events/AttemptSucceeded.php
@@ -2,7 +2,7 @@
 
 namespace FrancescoMalatesta\LaravelCircuitBreaker\Events;
 
-class AttemptSucceded
+class AttemptSucceeded
 {
     /** @var string */
     private $identifier;

--- a/src/Manager/CircuitBreakerManager.php
+++ b/src/Manager/CircuitBreakerManager.php
@@ -3,6 +3,7 @@
 namespace FrancescoMalatesta\LaravelCircuitBreaker\Manager;
 
 use FrancescoMalatesta\LaravelCircuitBreaker\Events\AttemptFailed;
+use FrancescoMalatesta\LaravelCircuitBreaker\Events\AttemptSucceded;
 use FrancescoMalatesta\LaravelCircuitBreaker\Events\ServiceFailed;
 use FrancescoMalatesta\LaravelCircuitBreaker\Events\ServiceRestored;
 use FrancescoMalatesta\LaravelCircuitBreaker\Service\ServiceOptionsResolver;
@@ -65,7 +66,14 @@ class CircuitBreakerManager
 
     public function reportSuccess(string $identifier) : void
     {
+        $wasAvailable = $this->isAvailable($identifier);
+
         $this->store->reportSuccess($identifier);
-        $this->dispatcher->dispatch(new ServiceRestored($identifier));
+
+        $this->dispatcher->dispatch(new AttemptSucceded($identifier));
+
+        if (!$wasAvailable && $this->isAvailable($identifier)) {
+            $this->dispatcher->dispatch(new ServiceRestored($identifier));
+        }
     }
 }

--- a/src/Manager/CircuitBreakerManager.php
+++ b/src/Manager/CircuitBreakerManager.php
@@ -3,7 +3,7 @@
 namespace FrancescoMalatesta\LaravelCircuitBreaker\Manager;
 
 use FrancescoMalatesta\LaravelCircuitBreaker\Events\AttemptFailed;
-use FrancescoMalatesta\LaravelCircuitBreaker\Events\AttemptSucceded;
+use FrancescoMalatesta\LaravelCircuitBreaker\Events\AttemptSucceeded;
 use FrancescoMalatesta\LaravelCircuitBreaker\Events\ServiceFailed;
 use FrancescoMalatesta\LaravelCircuitBreaker\Events\ServiceRestored;
 use FrancescoMalatesta\LaravelCircuitBreaker\Service\ServiceOptionsResolver;
@@ -70,7 +70,7 @@ class CircuitBreakerManager
 
         $this->store->reportSuccess($identifier);
 
-        $this->dispatcher->dispatch(new AttemptSucceded($identifier));
+        $this->dispatcher->dispatch(new AttemptSucceeded($identifier));
 
         if (!$wasAvailable && $this->isAvailable($identifier)) {
             $this->dispatcher->dispatch(new ServiceRestored($identifier));


### PR DESCRIPTION
## Description

I've added a new event `AttemptSucceded` and changed the way events are fired.

Now we have two main events:
- When the service is restored/braked;
- When the service get an attempt (failed or not).

They are split into four events:
- `AttemptFailed` fired by attempt method;
- `AttemptSucceeded` fired by attempt method;
- `ServiceFailed` fired by attempt method when the previous state is changed;
- `ServiceRestored` fired by attempt method when the previous state is changed.

## Motivation and context

We need to notify our slack uptime channel when circuit breaker is fired or a service is restored.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

Since the package don't have tests for event firing, I haven't built them.
